### PR TITLE
Reference correct KMS key attribute for DynamoDB SSE enryption key

### DIFF
--- a/dynamodb-table.tf
+++ b/dynamodb-table.tf
@@ -15,7 +15,7 @@ resource "aws_dynamodb_table" "remote_state_backend" {
 
   server_side_encryption {
     enabled     = true
-    kms_key_arn = aws_kms_key.remote_state_backend.key_id
+    kms_key_arn = aws_kms_key.remote_state_backend.arn
   }
 
   tags = local.common_tags


### PR DESCRIPTION
Referencing the 'key_id' attribute returns a GUID. aws_dynamodb_table resource expects an ARN. It doesn't appear that 4.1.0 can be used. This resolves the issue. I propose a 4.1.1 release.

## Change description

> Description here

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> #8 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
