### PR TITLE
Add optional inputs to allow defining DynamoDB table capacity mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,21 +104,27 @@ In this case, you just don't specific other accounts. Then, you use the default 
 ```hcl
 module "terraform_state" {
   source  = "StratusGrid/terraform-state-s3-bucket-centralized-with-roles/aws"
-  version = "~> 4.1"
+  version = "~> 5.1"
 
-  name_prefix   = var.name_prefix
-  name_suffix   = local.name_suffix
-  log_bucket_id = module.s3_bucket_logging.bucket_id
-  log_bucket_target_prefix = "s3/"
+  name_prefix = var.name_prefix
+  name_suffix = local.name_suffix
+
+  log_bucket_id                       = module.s3_bucket_logging.bucket_id
+  log_bucket_target_prefix            = "s3/"
   log_bucket_target_object_key_format = {
     partitioned_prefix = {
       partition_date_source = "EventTime"
     }
   }
-  account_arns = [
-  ]
+
+  account_arns        = []
   global_account_arns = []
-  input_tags          = merge(local.common_tags, {})
+
+  dynamodb_table_billing_type   = "PROVISIONED"
+  dynamodb_table_read_capacity  = 1
+  dynamodb_table_write_capacity = 1
+
+  input_tags = merge(local.common_tags, {})
 }
 
 output "terraform_state_kms_key_alias_arn" {
@@ -158,6 +164,9 @@ output "terraform_state_kms_key_arn" {
 | <a name="input_account_arns"></a> [account\_arns](#input\_account\_arns) | Arns for accounts / roles in accounts which are given a role they are able to assume to access their state. | `list(string)` | `[]` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Blocks public ACLs on the bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
+| <a name="input_dynamodb_table_billing_type"></a> [dynamodb\_table\_billing\_type](#input\_dynamodb\_table\_billing\_type) | Defines whether the DynamoDB table used for state locking and consistency checking should use on-demand or provisioned capacity mode. | `string` | `"PAY_PER_REQUEST"` | no |
+| <a name="input_dynamodb_table_read_capacity"></a> [dynamodb\_table\_read\_capacity](#input\_dynamodb\_table\_read\_capacity) | Defines the number of read units for the state locking and consistency table. If the dynamodb\_table\_billing\_type is PROVISIONED, this field is required. | `number` | `0` | no |
+| <a name="input_dynamodb_table_write_capacity"></a> [dynamodb\_table\_write\_capacity](#input\_dynamodb\_table\_write\_capacity) | Defines the number of write units for the state locking and consistency table. If the dynamodb\_table\_billing\_type is PROVISIONED, this field is required. | `number` | `0` | no |
 | <a name="input_global_account_arns"></a> [global\_account\_arns](#input\_global\_account\_arns) | Arns for a account(s) / roles in account(s) that would be allowed access to all account states, for instance a global users account. Restrictions of which of that accounts users were able to access a given state would need to be further restricted inside of the global account(s) themselves. | `list(string)` | `[]` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket. Causes Amazon S3 to ignore public ACLs on this bucket and any objects that it contains. | `bool` | `true` | no |
 | <a name="input_input_tags"></a> [input\_tags](#input\_input\_tags) | Map of tags to apply to resources | `map(string)` | `{}` | no |

--- a/dynamodb-table.tf
+++ b/dynamodb-table.tf
@@ -1,5 +1,7 @@
 resource "aws_dynamodb_table" "remote_state_backend" {
-  billing_mode = "PAY_PER_REQUEST"
+  billing_mode   = var.dynamodb_table_billing_type
+  read_capacity  = var.dynamodb_table_read_capacity
+  write_capacity = var.dynamodb_table_write_capacity
 
   attribute {
     name = "LockID"

--- a/examples/no_trusted_accounts.tfnot
+++ b/examples/no_trusted_accounts.tfnot
@@ -1,20 +1,26 @@
 module "terraform_state" {
   source  = "StratusGrid/terraform-state-s3-bucket-centralized-with-roles/aws"
-  version = "~> 4.1"
+  version = "~> 5.1"
 
-  name_prefix   = var.name_prefix
-  name_suffix   = local.name_suffix
-  log_bucket_id = module.s3_bucket_logging.bucket_id
-  log_bucket_target_prefix = "s3/"
+  name_prefix = var.name_prefix
+  name_suffix = local.name_suffix
+
+  log_bucket_id                       = module.s3_bucket_logging.bucket_id
+  log_bucket_target_prefix            = "s3/"
   log_bucket_target_object_key_format = {
     partitioned_prefix = {
       partition_date_source = "EventTime"
     }
   }
-  account_arns = [
-  ]
+
+  account_arns        = []
   global_account_arns = []
-  input_tags          = merge(local.common_tags, {})
+
+  dynamodb_table_billing_type   = "PROVISIONED"
+  dynamodb_table_read_capacity  = 1
+  dynamodb_table_write_capacity = 1
+
+  input_tags = merge(local.common_tags, {})
 }
 
 output "terraform_state_kms_key_alias_arn" {

--- a/inputs.tf
+++ b/inputs.tf
@@ -67,3 +67,26 @@ variable "restrict_public_buckets" {
   type        = bool
   default     = true
 }
+
+variable "dynamodb_table_billing_type" {
+  description = "Defines whether the DynamoDB table used for state locking and consistency checking should use on-demand or provisioned capacity mode."
+  type        = string
+  default     = "PAY_PER_REQUEST"
+
+  validation {
+    condition     = var.dynamodb_table_billing_type == "PAY_PER_REQUEST" || var.dynamodb_table_billing_type == "PROVISIONED"
+    error_message = "The dynamodb_table_billing_type value must be one of two valid options: PAY_PER_REQUEST or PROVISIONED. See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table#billing_mode for more information."
+  }
+}
+
+variable "dynamodb_table_read_capacity" {
+  description = "Defines the number of read units for the state locking and consistency table. If the dynamodb_table_billing_type is PROVISIONED, this field is required."
+  type        = number
+  default     = 0
+}
+
+variable "dynamodb_table_write_capacity" {
+  description = "Defines the number of write units for the state locking and consistency table. If the dynamodb_table_billing_type is PROVISIONED, this field is required."
+  type        = number
+  default     = 0
+}


### PR DESCRIPTION
## Change description

> Add optional dynamodb_table_billing_type, dynamodb_read_capacity, and dynamodb_write_capacity inputs. This allows the module's caller to define the state locking and constistancy table's capacity mode.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
