### PR TITLE
[feature] Allow the selection of the encryption type

### DIFF
--- a/.config/.terraform-docs.yml
+++ b/.config/.terraform-docs.yml
@@ -39,8 +39,8 @@ content: |-
   NOTE: The access and secret keys used must have rights to assume the role created by the module
   - This is usually automatically the case for any keys that have full admin rights in the account whose state is to be stored, or in one of the global accounts specified.
   - Otherwise, this will need to be assigned manually. You can use this module to help with mapping those trusts: https://registry.terraform.io/modules/StratusGrid/iam-cross-account-trust-maps/aws
-    - Use trusting_arn to map a single trust (like for a standard account assumption policy)
-    - Use trusting_arns to map multiple trusts (like for a global account assumption policy)
+  - Use trusting_arn to map a single trust (like for a standard account assumption policy)
+  - Use trusting_arns to map multiple trusts (like for a global account assumption policy)
   
   ## Example Configuration on Global Users Account:
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ output "terraform_state_kms_key_arn" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_arns"></a> [account\_arns](#input\_account\_arns) | Arns for accounts / roles in accounts which are given a role they are able to assume to access their state. | `list(string)` | `[]` | no |
+| <a name="input_aws_s3_bucket_server_side_encryption_type"></a> [aws\_s3\_bucket\_server\_side\_encryption\_type](#input\_aws\_s3\_bucket\_server\_side\_encryption\_type) | Selection of the bucket encryption type | `string` | `"SSE_KMS"` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Blocks public ACLs on the bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
 | <a name="input_dynamodb_table_billing_type"></a> [dynamodb\_table\_billing\_type](#input\_dynamodb\_table\_billing\_type) | Defines whether the DynamoDB table used for state locking and consistency checking should use on-demand or provisioned capacity mode. | `string` | `"PAY_PER_REQUEST"` | no |

--- a/inputs.tf
+++ b/inputs.tf
@@ -90,3 +90,21 @@ variable "dynamodb_table_write_capacity" {
   type        = number
   default     = 0
 }
+
+variable "aws_s3_bucket_server_side_encryption_type" {
+  description = "Selection of the bucket encryption type"
+  type        = string
+  default     = "SSE_KMS"
+
+  validation {
+    condition = contains([
+      "AWS_DEFAULT",
+      "SSE_S3",
+      "SSE_KMS"
+      ],
+      var.aws_s3_bucket_server_side_encryption_type
+    )
+
+    error_message = "The valid values are AWS_DEFAULT, SSE_S3, SSE_KMS"
+  }
+}


### PR DESCRIPTION
## Change description

> EPB client has set SCPs in some OUs that don't allow a change in the method encryption in the bucket (s3: PutBucketEncryption), not even define it in TF files; this change is to address that problem and allows selecting that configuration block in this module. It's safe because each bucket has as a default method encryption SSE-S3.
- The default value in the variable `aws_s3_bucket_server_side_encryption_type` is `SSE_KMS` to maintain backward compatibility.

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Related issues

> Fix [#1](https://stratusgrid.atlassian.net/browse/EPBCHA-41) 

## Checklists

### Development

- [X] Lint rules pass locally
- [X] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
