### PR TITLE
Update bucket policy to allow migrating Terraform state

### DIFF
--- a/s3-bucket.tf
+++ b/s3-bucket.tf
@@ -112,7 +112,6 @@ data "aws_iam_policy_document" "encrypted_transit_bucket_policy" {
       type = "AWS"
     }
     resources = [
-      aws_s3_bucket.remote_state_backend.arn,
       "${aws_s3_bucket.remote_state_backend.arn}/*"
     ]
     sid = "DenyIncorrectEncryptionHeader"
@@ -136,7 +135,6 @@ data "aws_iam_policy_document" "encrypted_transit_bucket_policy" {
       type = "AWS"
     }
     resources = [
-      aws_s3_bucket.remote_state_backend.arn,
       "${aws_s3_bucket.remote_state_backend.arn}/*"
     ]
     sid = "DenyUnencryptedObjectUploads"
@@ -160,7 +158,6 @@ data "aws_iam_policy_document" "encrypted_transit_bucket_policy" {
       type = "AWS"
     }
     resources = [
-      aws_s3_bucket.remote_state_backend.arn,
       "${aws_s3_bucket.remote_state_backend.arn}/*"
     ]
     sid = "RequireBucketOwnerACL"


### PR DESCRIPTION
## Change description

> Some statements in the remote state S3 bucket's policy were referencing bucket and object ARNs but were allowing actions that only applied to objects. This was prevents users from migrating their local Terraform state file to the remote state backend.
>
> Removed bucket ARNs from the remote state S3 bucket's policy for statements that allowed only actions that only applied to objects and not buckets.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> [SGINT-906](https://stratusgrid.atlassian.net/browse/SGINT-906)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable


[SGINT-906]: https://stratusgrid.atlassian.net/browse/SGINT-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ